### PR TITLE
Fix/bot send oauth

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -128,7 +128,8 @@ class Client {
 
     // convert json except when passing in a url
     if (!endPoint.match(/^http/i)) message = qs.stringify(message);
-    return this.api.post(endPoint, message).then(this.getData);
+    // this is to cater for the fact that it will throw an oauth error -since we installed directly on Slack management console
+    return this.api.post(endPoint, message).then(this.getData).catch(error => { console.log(error) });
   }
 
 


### PR DESCRIPTION
According to the docs you need to install the app via the GET URL returned by AWS. I am not using that approach, but because of this I kept receiving the following error:

```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): [object Object]
```

This PR handles that error, to keep my console quiet.

It's more like a workaround, to keep the peace.

its similar to this issue over here -> https://github.com/johnagan/serverless-slack/issues/3